### PR TITLE
Adjusted USB timeout to be more permissive during sensor dump and handle USB timeouts more gracefully.

### DIFF
--- a/app/flight/appa/rev2/prelaunch.c
+++ b/app/flight/appa/rev2/prelaunch.c
@@ -120,7 +120,7 @@ if ( usb_detect() )
                     }
                 else
                     {
-                    error_fail_fast( command_status );
+                    error_fail_fast( ERROR_SENSOR_CMD_ERROR );
                     }
                 break;
                 } /* SENSOR_OP */


### PR DESCRIPTION
Bugfix for dashboard development. Merging this pull request will trigger pre-release v2.6-002 to ensure greater reliability for the dashboard team in testing.

@xeflore1 pinged for awareness.