### PR TITLE
Remove redundant buffer writes

### DIFF
--- a/app/flight/appa/rev2/flash_appa.c
+++ b/app/flight/appa/rev2/flash_appa.c
@@ -98,13 +98,6 @@ if( flash_status != FLASH_OK )
 /*------------------------------------------------------------------------------
  Store Data 
 ------------------------------------------------------------------------------*/
-uint8_t save_bit = 1;
-/* Put data into buffer for flash write */
-
-buffer[0] = save_bit;
-buffer[1] = get_fc_state();
-memcpy( &buffer[2], &time          , sizeof( uint32_t    ) );
-
 /* Set buffer pointer */
 pflash_handle->pbuffer   = &buffer[0];
 pflash_handle->num_bytes = sensor_frame_size;
@@ -309,7 +302,7 @@ uint8_t idx = 0; /* current index in the buffer */
 memset(buffer, 0, sensor_frame_size);
 buffer[0] = 1; /* save bit */
 buffer[1] = get_fc_state();
-buffer[2] = time;
+memcpy( &buffer[2], &time, sizeof( uint32_t ) );
 idx = 6;
 
 if ( preset_data.config_settings.enabled_data & STORE_CONV )


### PR DESCRIPTION
## Description
Move save bit, FC state, and time copies into buffer to get_sensor_frame

### Issue Link
None

### Testing
- [x] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code