### PR TITLE
Integration: Add LED to rev3

### DIFF
--- a/app/rev3/Makefile
+++ b/app/rev3/Makefile
@@ -44,6 +44,7 @@ C_SOURCES =  \
 main.c \
 $(INIT_DIR)/config/Src/stm32h7xx_it.c \
 $(INIT_DIR)/config/Src/stm32h7xx_hal_msp.c \
+$(DRIVER_DIR)/led/led.c						\
 $(DRIVER_DIR)/usb/USB_DEVICE/App/usb_device.c \
 $(DRIVER_DIR)/usb/USB_DEVICE/App/usbd_desc.c \
 $(DRIVER_DIR)/usb/USB_DEVICE/App/usbd_cdc_if.c \
@@ -135,6 +136,7 @@ AS_DEFS =
 C_DEFS =  \
 -DUSE_PWR_LDO_SUPPLY \
 -DUSE_HAL_DRIVER \
+-DA0010			 \
 -DSTM32H733xx
 
 
@@ -144,9 +146,11 @@ AS_INCLUDES =
 # C includes
 C_INCLUDES =  \
 -I.									\
+-I$(DRIVER_DIR)/led					\
 -I$(DRIVER_DIR)/usb/USB_DEVICE/App \
 -I$(DRIVER_DIR)/usb/USB_DEVICE/Target \
 -I$(INIT_DIR)/config/Inc \
+-I$(LIB_DIR)								\
 -I$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc \
 -I$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/Legacy \
 -I$(LIB_DIR)/Middlewares/ST/STM32_USB_Device_Library/Core/Inc \


### PR DESCRIPTION
## Description
Just adds the LED driver to the R3 makefile.

### Issue Link
Parent: https://github.com/SunDevilRocketry/driver/pull/11

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Rev3 Initial: N/A.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code