### PR TITLE
Add Emulator SSE Compile Flags

### DIFF
--- a/app/rev2/Makefile
+++ b/app/rev2/Makefile
@@ -235,7 +235,36 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 
 ifeq ($(EMULATOR), 1)
     C_SOURCES += $(EMULATOR_SOURCES)
-    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc -isystem $(LIB_DIR)/Drivers/CMSIS/Include -isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include -I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW -I$(BASE_DIR)/emulator/vendor/glad/include -march=native
+    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc -isystem $(LIB_DIR)/Drivers/CMSIS/Include -isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include -I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW -I$(BASE_DIR)/emulator/vendor/glad/include 
+
+	# Check for simd support
+	# Checks if grep can find sse[x] in cpuinfo
+	# Only works for linux but that's fine for cygwin & linux users
+	ifneq ($(OS), Darwin)
+		# Detecting sse & sse2 may be unnecessary because I believe those are required on x86-64 targets
+		HAS_SSE = $(shell grep -o sse /proc/cpuinfo | wc -m)
+		ifneq ($(HAS_SSE), 0)
+			CFLAGS += -msse
+		endif
+
+		HAS_SSE2 = $(shell grep -o sse2 /proc/cpuinfo | wc -m)
+		ifneq ($(HAS_SSE2), 0)
+			CFLAGS += -msse2
+		endif
+
+		HAS_SSE3 = $(shell grep -o sse3 /proc/cpuinfo | wc -m)
+		ifneq ($(HAS_SSE3), 0)
+			CFLAGS += -msse3
+		endif
+
+		HAS_SSE4 = $(shell grep -o sse4 /proc/cpuinfo | wc -m)
+		ifneq ($(HAS_SSE4), 0)
+			CFLAGS += -msse4
+		endif
+	else
+		# Do nothing on Mac because I don't know how to check for this
+	endif
+
     CC = gcc
     AS = gcc -x assembler-with-cpp
     CP = objcopy

--- a/app/rev2/Makefile
+++ b/app/rev2/Makefile
@@ -235,7 +235,7 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 
 ifeq ($(EMULATOR), 1)
     C_SOURCES += $(EMULATOR_SOURCES)
-    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc -isystem $(LIB_DIR)/Drivers/CMSIS/Include -isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include -I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW -I$(BASE_DIR)/emulator/vendor/glad/include
+    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc -isystem $(LIB_DIR)/Drivers/CMSIS/Include -isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include -I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW -I$(BASE_DIR)/emulator/vendor/glad/include -march=native
     CC = gcc
     AS = gcc -x assembler-with-cpp
     CP = objcopy


### PR DESCRIPTION
## Description
Adds SSE compile flags based on cpu support

### Issue Link
N/A

Parent: Emulator [#44](https://github.com/SunDevilRocketry/sdr-emulator/pull/44)

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
meow

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code