### PR TITLE
Update emulator build for miniaudio (DRAFT)

### DIFF
--- a/app/rev2/Makefile
+++ b/app/rev2/Makefile
@@ -115,6 +115,7 @@ $(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c
 # Source files for the FC emulator
 EMULATOR_SOURCES =													  \
 $(BASE_DIR)/emulator/src/emulator.c									  \
+$(BASE_DIR)/emulator/src/emulator_audio.c							  \
 $(BASE_DIR)/emulator/src/emulator_timer.c							  \
 $(BASE_DIR)/emulator/src/emulator_error.c							  \
 $(BASE_DIR)/emulator/src/emulator_init.c							  \
@@ -235,13 +236,18 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 
 ifeq ($(EMULATOR), 1)
     C_SOURCES += $(EMULATOR_SOURCES)
-    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc -isystem $(LIB_DIR)/Drivers/CMSIS/Include -isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include -I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW -I$(BASE_DIR)/emulator/vendor/glad/include
+    CFLAGS += -DEMULATOR -DCORE_CM4 -I$(BASE_DIR)/emulator/inc \
+	-isystem $(LIB_DIR)/Drivers/CMSIS/Include \
+	-isystem $(LIB_DIR)/Drivers/CMSIS/Device/ST/STM32H7xx/Include\
+	-I$(BASE_DIR)/emulator/vendor/glfw/include/GLFW \
+	-I$(BASE_DIR)/emulator/vendor/glad/include \
+	-isystem $(BASE_DIR)/emulator/vendor/miniaudio
     CC = gcc
     AS = gcc -x assembler-with-cpp
     CP = objcopy
     SZ = size
     ASM_SOURCES =
-    LIBS = -lm -L$(BUILD_DIR)/glfw/lib -l:libglfw.a -L$(BUILD_DIR)/glad/lib -lglad
+    LIBS = -lm -L$(BUILD_DIR)/glfw/lib -l:libglfw.a -L$(BUILD_DIR)/glad/lib -lglad -L$(BUILD_DIR)/miniaudio/lib -l:miniaudio.a
 
 	# Platform specific libraries (mac,linux) for windowing here 
 	ifeq ($(OS), Windows_NT)


### PR DESCRIPTION
## Description
Augments the build system to link the miniaudio library.

### Issue Link
N/A

Parent: https://github.com/SunDevilRocketry/sdr-emulator/pull/46

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code