### PR TITLE
Compile out timer.c for emulator builds

### DIFF
--- a/app/rev2/Makefile
+++ b/app/rev2/Makefile
@@ -77,7 +77,6 @@ $(MOD_DIR)/sensor/sensor.c                                            \
 $(DRIVER_DIR)/usb/usb.c                                                  \
 $(DRIVER_DIR)/gps/gps.c                                                  \
 $(DRIVER_DIR)/servo/servo.c                                              \
-$(DRIVER_DIR)/timer/timer.c                                              \
 
 # Hardware dependent sources (used in HW builds, compiled out in emulator)
 HW_DEPENDENT_SOURCES = 												  \
@@ -110,7 +109,8 @@ $(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_spi_ex.c    \
 $(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_sdmmc.c      \
 $(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_delayblock.c \
 $(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd.c        \
-$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c
+$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_sd_ex.c \
+$(DRIVER_DIR)/timer/timer.c                                              \
 
 # Source files for the FC emulator
 EMULATOR_SOURCES =													  \
@@ -212,7 +212,7 @@ C_INCLUDES =                                           \
 -I$(DRIVER_DIR)/gps                                       \
 -I$(DRIVER_DIR)/timer                                     \
 -I$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc          \
--I$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/Legacy
+-I$(LIB_DIR)/Drivers/STM32H7xx_HAL_Driver/Inc/Legacy	\
 
 # compile gcc flags
 ASFLAGS = $(AS_DEFS) $(AS_INCLUDES) -Wall -fdata-sections -ffunction-sections


### PR DESCRIPTION
## Description
Compiles out timer.c in emulator builds to allow mocking.

### Issue Link
Emulator [#52](https://github.com/SunDevilRocketry/sdr-emulator/issues/52)

Parent PR: Emulator [#53](https://github.com/SunDevilRocketry/sdr-emulator/pull/53)

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code