### PR TITLE
Improve error handling/recovery for I2C sensors

### DIFF
--- a/app/rev2/flight.c
+++ b/app/rev2/flight.c
@@ -520,6 +520,7 @@ switch( get_fc_state() )
         break;
     case FC_STATE_ASCENT:
     case FC_STATE_APOGEE:  /* intentional fallthrough */
+    case FC_STATE_COAST:   /* intentional fallthrough */
     case FC_STATE_DESCENT: /* intentional fallthrough */
         if ( flash_full )
             {

--- a/app/rev2/main.c
+++ b/app/rev2/main.c
@@ -142,6 +142,9 @@ SERVO_STATUS servo_status;
 /* Flash */
 uint32_t flash_address;
 
+/* Init error recovery */
+uint32_t init_timeout;
+
 
 /*------------------------------------------------------------------------------
  Variable Initializations                                                               
@@ -197,6 +200,8 @@ sensor_status                 = SENSOR_OK;
 /* General Board configuration */
 firmware_code                 = FIRMWARE_APPA;
 
+/* Init error recovery */
+init_timeout				  = 500;
 
 /*------------------------------------------------------------------------------
  MCU/HAL Initialization                                                                  
@@ -235,16 +240,26 @@ sensor_init();
 
 /* Barometric pressure sensor */
 baro_status = baro_init( &baro_configs );
-if ( baro_status != BARO_OK )
+while ( baro_status != BARO_OK )
 	{
-	error_fail_fast( ERROR_BARO_INIT_ERROR );
+	baro_status = baro_init( &baro_configs );
+	
+	if( HAL_GetTick() > init_timeout )
+		{
+		error_fail_fast( ERROR_BARO_INIT_ERROR );
+		}
 	}
 
 /* IMU */
 imu_status = imu_init( &imu_configs );
-if ( imu_status != IMU_OK )
+while ( imu_status != IMU_OK )
 	{
-	error_fail_fast( ERROR_IMU_INIT_ERROR );
+	imu_status = imu_init( &imu_configs );
+
+	if( HAL_GetTick() > init_timeout )
+		{
+		error_fail_fast( ERROR_IMU_INIT_ERROR );
+		}
 	}
 
 /* Servo */

--- a/app/rev2/main.c
+++ b/app/rev2/main.c
@@ -235,6 +235,7 @@ sensor_init();
 baro_status = baro_init( &baro_configs );
 while ( baro_status != BARO_OK )
 	{
+    HAL_Delay(10);
 	baro_status = baro_init( &baro_configs );
 
 	if( HAL_GetTick() > I2C_INIT_TIMEOUT )
@@ -247,6 +248,7 @@ while ( baro_status != BARO_OK )
 imu_status = imu_init( &imu_configs );
 while ( imu_status != IMU_OK )
 	{
+    HAL_Delay(10);
 	imu_status = imu_init( &imu_configs );
 
 	if( HAL_GetTick() > I2C_INIT_TIMEOUT )

--- a/app/rev2/main.c
+++ b/app/rev2/main.c
@@ -142,10 +142,6 @@ SERVO_STATUS servo_status;
 /* Flash */
 uint32_t flash_address;
 
-/* Init error recovery */
-uint32_t init_timeout;
-
-
 /*------------------------------------------------------------------------------
  Variable Initializations                                                               
 ------------------------------------------------------------------------------*/
@@ -200,9 +196,6 @@ sensor_status                 = SENSOR_OK;
 /* General Board configuration */
 firmware_code                 = FIRMWARE_APPA;
 
-/* Init error recovery */
-init_timeout				  = 500;
-
 /*------------------------------------------------------------------------------
  MCU/HAL Initialization                                                                  
 ------------------------------------------------------------------------------*/
@@ -243,8 +236,8 @@ baro_status = baro_init( &baro_configs );
 while ( baro_status != BARO_OK )
 	{
 	baro_status = baro_init( &baro_configs );
-	
-	if( HAL_GetTick() > init_timeout )
+
+	if( HAL_GetTick() > I2C_INIT_TIMEOUT )
 		{
 		error_fail_fast( ERROR_BARO_INIT_ERROR );
 		}
@@ -256,7 +249,7 @@ while ( imu_status != IMU_OK )
 	{
 	imu_status = imu_init( &imu_configs );
 
-	if( HAL_GetTick() > init_timeout )
+	if( HAL_GetTick() > I2C_INIT_TIMEOUT )
 		{
 		error_fail_fast( ERROR_IMU_INIT_ERROR );
 		}

--- a/app/rev2/main.h
+++ b/app/rev2/main.h
@@ -60,14 +60,17 @@ extern "C" {
 	/* Disable timeouts when debugging */
 	#define HAL_DEFAULT_TIMEOUT    ( 0xFFFFFFFF )  
 	#define HAL_SENSOR_TIMEOUT     ( 0xFFFFFFFF ) 
+	#define I2C_INIT_TIMEOUT	   ( 0xFFFFFFFF )
 #elif defined( EMULATOR )
 	/* The emulator is not real-time, so make the timeouts more permissive */
 	#define HAL_DEFAULT_TIMEOUT    ( 1000 )  
-	#define HAL_SENSOR_TIMEOUT     ( 4000 ) 
+	#define HAL_SENSOR_TIMEOUT     ( 4000 )
+	#define I2C_INIT_TIMEOUT	   ( 5000 )
 #else
 	#define HAL_DEFAULT_TIMEOUT    ( 10  ) /* Default timeout for polling 
 	                                          operations                     */
 	#define HAL_SENSOR_TIMEOUT     ( 40  ) /* Timeout for sensor polling      */
+	#define I2C_INIT_TIMEOUT	   ( 500 )
 #endif /* SDR_DEBUG */
 
 /* Version Information */

--- a/app/rev2/main.h
+++ b/app/rev2/main.h
@@ -70,7 +70,7 @@ extern "C" {
 	#define HAL_DEFAULT_TIMEOUT    ( 10  ) /* Default timeout for polling 
 	                                          operations                     */
 	#define HAL_SENSOR_TIMEOUT     ( 40  ) /* Timeout for sensor polling      */
-	#define I2C_INIT_TIMEOUT	   ( 500 )
+	#define I2C_INIT_TIMEOUT	   ( 750 )
 #endif /* SDR_DEBUG */
 
 /* Version Information */

--- a/app/rev2/sensor_calibrate.c
+++ b/app/rev2/sensor_calibrate.c
@@ -30,6 +30,7 @@
 #include "usb.h"
 #include "imu.h"
 #include "sensor.h"
+#include "error_sdr.h"
 
 /*------------------------------------------------------------------------------
 Instantiations                                                                  
@@ -62,6 +63,7 @@ float baro_temp_nonzero[1000];
 *******************************************************************************/
 void sensorCalibrationSWCON(){
     uint16_t samples = preset_data.config_settings.sensor_calibration_samples;
+    SENSOR_STATUS sensor_status = SENSOR_OK;
 
     preset_data.imu_offset.accel_x = 0.00;
     preset_data.imu_offset.accel_y = 0.00;
@@ -91,7 +93,8 @@ void sensorCalibrationSWCON(){
     float calc_baro_temp = 0.00;
 
     for (int i = 0; i < samples; i++){
-        sensor_dump( &sensor_data );
+        sensor_status = sensor_dump( &sensor_data );
+        debug_assert( sensor_status == SENSOR_OK, ERROR_SENSOR_CMD_ERROR );
         calc_acc_x = calc_acc_x + sensor_data.imu_data.imu_converted.accel_x;
         calc_acc_y = calc_acc_y + sensor_data.imu_data.imu_converted.accel_y;
         calc_acc_z = calc_acc_z + sensor_data.imu_data.imu_converted.accel_z;

--- a/init/rev2/config/Src/stm32h7xx_it.c
+++ b/init/rev2/config/Src/stm32h7xx_it.c
@@ -289,12 +289,12 @@ if ( htim->Instance == TIM5 )
 
 
 void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c) {
-  if( hi2c == &hi2c1 )
+  if( hi2c == &( BARO_I2C ) )
     {
     /* baro */
     baro_IT_handler();
     }
-  else if( hi2c == &hi2c2 )
+  else if( hi2c == &( IMU_I2C ) )
     {
     /* imu */
     imu_it_handler();
@@ -306,13 +306,13 @@ void HAL_I2C_ErrorCallback( I2C_HandleTypeDef *hi2c )
     {
     volatile uint32_t error = HAL_I2C_GetError( hi2c );
     (void)error; /* debug mode won't optimize this code away */
-    if ( hi2c->Instance == I2C1 )
+    if ( hi2c == &( BARO_I2C ) )
         {
         #ifdef DEBUG
         error_fail_fast( ERROR_BARO_I2C_ERROR );
         #endif
         }
-    else if ( hi2c->Instance == I2C2 )
+    else if ( hi2c == &( IMU_I2C ) )
         {
         #ifdef DEBUG
         error_fail_fast( ERROR_IMU_I2C_ERROR );
@@ -322,7 +322,7 @@ void HAL_I2C_ErrorCallback( I2C_HandleTypeDef *hi2c )
 
 
 void HAL_SPI_TxRxCpltCallback( SPI_HandleTypeDef *hspi ) {
-    if ( hspi == &(hspi4) ) {
+    if ( hspi == &( LORA_SPI ) ) {
         /* Driver contract: pull NSS high */
         HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_SET );
         /* Update telemetry FSM */
@@ -332,7 +332,7 @@ void HAL_SPI_TxRxCpltCallback( SPI_HandleTypeDef *hspi ) {
 
 
 void HAL_SPI_TxCpltCallback( SPI_HandleTypeDef *hspi ) {
-    if ( hspi == &(hspi4) ) {
+    if ( hspi == &( LORA_SPI ) ) {
         /* Driver contract: pull NSS high */
         HAL_GPIO_WritePin( LORA_NSS_GPIO_PORT, LORA_NSS_PIN, GPIO_PIN_SET );
         /* Update telemetry FSM */

--- a/init/rev2/config/Src/stm32h7xx_it.c
+++ b/init/rev2/config/Src/stm32h7xx_it.c
@@ -39,6 +39,7 @@ Standard Includes
 #include "baro.h"
 #include "timer.h"
 #include "telemetry.h"
+#include "error_sdr.h"
 #include <string.h>
 
 /*------------------------------------------------------------------------------
@@ -186,6 +187,15 @@ void I2C2_EV_IRQHandler(void)
 
 
 /**
+  * @brief This function handles I2C2 error interrupt. (IMU)
+  */
+void I2C2_ER_IRQHandler(void)
+{
+  HAL_I2C_ER_IRQHandler(&hi2c2);
+}
+
+
+/**
   * @brief This function handles SPI4 global interrupt.
   */
 void SPI4_IRQHandler(void)
@@ -290,6 +300,19 @@ void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c) {
     imu_it_handler();
     }
 }
+
+
+void HAL_I2C_ErrorCallback( I2C_HandleTypeDef *hi2c )
+    {
+    if( hi2c->Instance == I2C2 )
+        {
+        volatile uint32_t error = HAL_I2C_GetError( hi2c );
+        (void)error;
+        #ifdef DEBUG
+        error_fail_fast( ERROR_IMU_INIT_ERROR );
+        #endif
+        }
+    }
 
 
 void HAL_SPI_TxRxCpltCallback( SPI_HandleTypeDef *hspi ) {

--- a/init/rev2/config/Src/stm32h7xx_it.c
+++ b/init/rev2/config/Src/stm32h7xx_it.c
@@ -304,12 +304,18 @@ void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c) {
 
 void HAL_I2C_ErrorCallback( I2C_HandleTypeDef *hi2c )
     {
-    if( hi2c->Instance == I2C2 )
+    volatile uint32_t error = HAL_I2C_GetError( hi2c );
+    (void)error; /* debug mode won't optimize this code away */
+    if ( hi2c->Instance == I2C1 )
         {
-        volatile uint32_t error = HAL_I2C_GetError( hi2c );
-        (void)error;
         #ifdef DEBUG
-        error_fail_fast( ERROR_IMU_INIT_ERROR );
+        error_fail_fast( ERROR_BARO_I2C_ERROR );
+        #endif
+        }
+    else if ( hi2c->Instance == I2C2 )
+        {
+        #ifdef DEBUG
+        error_fail_fast( ERROR_IMU_I2C_ERROR );
         #endif
         }
     }


### PR DESCRIPTION
## Description
Adds some additional handling to main.c's init routines for I2C sensors to hopefully mitigate #192. Adds an error callback for the I2C handles outside of init. Adds a debug assert for issues with sensor dump in sensor calibrate, and adds handling for the coast phase of flight in the LED helper to not trigger a debug assert there.

### Issue Link
Relates to #279 (does not close). 
Closes #192.

Children:
- Driver: https://github.com/SunDevilRocketry/driver/pull/36
- Mod: https://github.com/SunDevilRocketry/mod/pull/130

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [X] Integration test performed

If a non-automated test was executed that provides an artifact, please attach below (e.g. flash extract data).

### Other
N/A

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Accuracy
- [ ] Code implements the correct requirement (a.k.a. does the right thing)
- [ ] Code is logically correct (a.k.a. does the thing right)

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled
- [ ] Fail-fast errors are only thrown when unsafe to continue software execution
- [ ] Debug errors are thrown for exceptions where execution should still continue (to be noticed during development)

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is not used
- [ ] Statically/Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrent access has been considered (especially by/from interrupt service routines)

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided in performance sensitive code
- [ ] "Delay" calls are not used in performance sensitive code
- [ ] If performance is negatively impacted, a justification is provided and the impact is quantified
