### PR TITLE
Add automatic GDB commands to makefile

### DIFF
--- a/app/rev2/Makefile
+++ b/app/rev2/Makefile
@@ -24,6 +24,17 @@ EMULATOR ?= 0
 DEBUG_OPT = -Og
 REL_OPT = -O2
 
+################################################################
+# GDB
+################################################################
+
+# commands automatically passed to gdb
+define GDB_COMMANDS
+target extended localhost:4242
+b main
+load
+c
+endef
 
 ################################################################
 # paths
@@ -364,7 +375,9 @@ clean:
 # debug
 ################################################################
 debug:
-	arm-none-eabi-gdb build/$(TARGET).elf
+	$(file > gdb_cmds.txt, $(GDB_COMMANDS))
+	arm-none-eabi-gdb -q -x gdb_cmds.txt build/$(TARGET).elf
+	rm gdb_cmds.txt
 
 
 ################################################################


### PR DESCRIPTION
## Description
Adds commands that will automatically be passed to GDB when running `make debug`

`-q` (quiet) suppresses the intro banner

### Issue Link
No issue link.

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [ ] Integration test performed

Testing N/A

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Accuracy
- [ ] Code implements the correct requirement (a.k.a. does the right thing)
- [ ] Code is logically correct (a.k.a. does the thing right)

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled
- [ ] Fail-fast errors are only thrown when unsafe to continue software execution
- [ ] Debug errors are thrown for exceptions where execution should still continue (to be noticed during development)

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is not used
- [ ] Statically/Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrent access has been considered (especially by/from interrupt service routines)

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided in performance sensitive code
- [ ] "Delay" calls are not used in performance sensitive code
- [ ] If performance is negatively impacted, a justification is provided and the impact is quantified
