### PR TITLE
Remove sensor init

### DIFF
--- a/app/rev2/main.c
+++ b/app/rev2/main.c
@@ -227,9 +227,6 @@ if ( flash_status != FLASH_OK )
 	error_fail_fast( ERROR_FLASH_INIT_ERROR );
 	}
 
-/* Sensor Module - Sets up the sensor sizes/offsets table */
-sensor_init();
-
 /* Barometric pressure sensor */
 baro_status = baro_init( &baro_configs );
 while ( baro_status != BARO_OK )

--- a/test/app/rev2/main/mock/mocks.c
+++ b/test/app/rev2/main/mock/mocks.c
@@ -122,14 +122,6 @@ FLASH_STATUS flash_init
 return flash_init_return;
 }
 
-void sensor_init 
-	(
-	void
-	)
-{
-// stub
-}
-
 BARO_STATUS baro_init
 	(
 	BARO_CONFIG* config_ptr


### PR DESCRIPTION
## Description
Removes sensor init as part of sensor.c nuke

### Issue Link
Parent: https://github.com/SunDevilRocketry/mod/pull/131

### Testing
- [x] Passes existing unit tests
- [x] Unit tests modified
- [ ] Integration test performed

If a non-automated test was executed that provides an artifact, please attach below (e.g. flash extract data).

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Accuracy
- [ ] Code implements the correct requirement (a.k.a. does the right thing)
- [ ] Code is logically correct (a.k.a. does the thing right)

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled
- [ ] Fail-fast errors are only thrown when unsafe to continue software execution
- [ ] Debug errors are thrown for exceptions where execution should still continue (to be noticed during development)

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is not used
- [ ] Statically/Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrent access has been considered (especially by/from interrupt service routines)

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided in performance sensitive code
- [ ] "Delay" calls are not used in performance sensitive code
- [ ] If performance is negatively impacted, a justification is provided and the impact is quantified
