### PR TITLE
DevOps: Alert on build failures to a discord channel

### DIFF
--- a/.github/workflows/build-stability.yml
+++ b/.github/workflows/build-stability.yml
@@ -55,3 +55,10 @@ jobs:
           make clean
           make
       - run: echo "🍏 This job's status is ${{ job.status }}."
+
+      - name: Notify Discord on Failure
+        uses: nebularg/actions-discord-webhook@v1
+        if: failure() && github.ref_name == 'main'
+        with:
+          webhook_url: ${{ secrets.DISCORD_BUILD_ALERT_WEBHOOK }}
+          status: ${{ job.status }}


### PR DESCRIPTION
(Will be self merged, but I want the PR to document this)

No functional changes to firmware code, this simply alerts in case of build failures so I can triage
